### PR TITLE
Fix spotify GPG key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: install Spotify GPG key
   apt_key:
-    url: https://download.spotify.com/debian/pubkey_0D811D58.gpg
+    url: https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg
     state: present
 
 - name: enable Spotify repo


### PR DESCRIPTION
In the meantime the key seems to have changed. I added the one from these official instructions:

https://www.spotify.com/de-en/download/linux/